### PR TITLE
Add compatibility with systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ standalone mode the shortcut is created in Startup forlder of specified
 user. This mode is required in some cases to overcome service's
 shortcomings (it could interact with desktop, so, it could not for
 example create direct3d device).
-Default on Windows is `service` and on Linux `init`.
+Default on Windows is `service` and on Linux `init` or `systemd` depending
+on your OS version.
 
 ####`teamcity_agent_mem_opts`
 String for configuring additional java parameters for build agent.

--- a/README.md
+++ b/README.md
@@ -89,13 +89,14 @@ Required service status. Defaults to `running`.
 Should the service be enabled. Defaults to `true`.
 
 ####`service_run_type`
-The mode in which agent is executed: it could be `service` or `standalone`.
-This parameter is only for Windows system: if set to `service`, then agent
-is executed as regular windows service. In standalone mode the shortcut
-is created in Startup forlder of specified user. This mode is required in
-some cases to overcome service's shortcomings (it could interact with
-desktop, so, it could not for example create direct3d device).
-Default is `service`.
+The mode in which agent is executed: it could be `service` or `standalone`
+for Windows and `init` or `systemd` on Linux. On Windows system: if set
+to `service`, then agent is executed as regular windows service. In 
+standalone mode the shortcut is created in Startup forlder of specified
+user. This mode is required in some cases to overcome service's
+shortcomings (it could interact with desktop, so, it could not for
+example create direct3d device).
+Default on Windows is `service` and on Linux `init`.
 
 ####`teamcity_agent_mem_opts`
 String for configuring additional java parameters for build agent.

--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -1,7 +1,6 @@
 # PRIVATE CLASS: do not call directly
 class teamcity::account {
   $agent_dir               = $teamcity::agent::agent_dir
-
   $agent_user              = $teamcity::agent::agent_user
   $agent_user_home         = $teamcity::agent::agent_user_home
   $manage_agent_user_home  = $teamcity::agent::manage_agent_user_home

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -55,6 +55,10 @@
 #   Should the service be enabled
 #   Defaults to `true`.
 #
+# [*service_run_type*]
+#   Daemon type init or systemd
+#   Defaults to `init`.
+#
 # [*teamcity_agent_mem_opts*]
 #   String for configuring additional java parameters for build agent
 #

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -56,8 +56,8 @@
 #   Defaults to `true`.
 #
 # [*service_run_type*]
-#   Daemon type init or systemd
-#   Defaults to `init`.
+#   Service type
+#   On windows defaults to `service`, on Linux defaults to `init`.
 #
 # [*teamcity_agent_mem_opts*]
 #   String for configuring additional java parameters for build agent

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -1,6 +1,7 @@
 # PRIVATE CLASS: do not call directly
 class teamcity::agent::config {
   $agent_name              = $teamcity::agent::agent_name
+  $agent_user              = $teamcity::agent::agent_user
   $agent_dir               = $teamcity::agent::agent_dir
   $server_url              = $teamcity::agent::server_url
   $custom_properties       = $teamcity::agent::custom_properties

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -48,5 +48,12 @@ class teamcity::agent::config {
       mode    => '0755',
       content => template("${module_name}/teamcity-profile.erb"),
     }
+    # systemd compatible
+    file { ' /lib/systemd/system/build-agent.service':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => template("${module_name}/build-agent-service.erb"),
+    }
   }
 }

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -2,12 +2,20 @@
 class teamcity::agent::config {
   $agent_name              = $teamcity::agent::agent_name
   $agent_user              = $teamcity::agent::agent_user
-  $agent_dir               = $teamcity::agent::agent_dir
+  $agent_user_home         = $teamcity::agent::agent_user_home
+  $manage_agent_user_home  = $teamcity::agent::manage_agent_user_home
+  $agent_group             = $teamcity::agent::agent_group
+  $manage_group            = $teamcity::agent::manage_group
   $server_url              = $teamcity::agent::server_url
+  $archive_name            = $teamcity::agent::archive_name
+  $download_url            = $teamcity::agent::download_url
+  $agent_dir               = $teamcity::agent::agent_dir
+  $service_ensure          = $teamcity::agent::service_ensure
+  $service_enable          = $teamcity::agent::agent_dir
+  $service_run_type        = $teamcity::agent::service_run_type
   $custom_properties       = $teamcity::agent::custom_properties
   $launcher_wrapper_conf   = $teamcity::agent::launcher_wrapper_conf
   $teamcity_agent_mem_opts = $teamcity::agent::teamcity_agent_mem_opts
-  $service_run_type        = $teamcity::agent::service_run_type
 
   $required_properties = {
     'serverUrl' => $server_url,

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -49,7 +49,7 @@ class teamcity::agent::config {
       content => template("${module_name}/teamcity-profile.erb"),
     }
     # systemd compatible
-    file { ' /lib/systemd/system/build-agent.service':
+    file { '/lib/systemd/system/build-agent.service':
       owner   => 'root',
       group   => 'root',
       mode    => '0755',

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -47,7 +47,7 @@ class teamcity::agent::install {
     }
 
     exec { 'extract-agent-archive':
-      command   => "unzip ${::temp_dir}${archive_name} -d ${agent_dir}",
+      command   => "unzip ${::temp_dir}/${archive_name} -d ${agent_dir}",
       creates   => "${agent_dir}/conf",
       logoutput => 'on_failure',
       require   => Wget::Fetch['teamcity-buildagent']

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -47,7 +47,7 @@ class teamcity::agent::install {
     }
 
     exec { 'extract-agent-archive':
-      command   => "unzip /tmp/${archive_name} -d ${agent_dir}",
+      command   => "unzip ${::temp_dir}${archive_name} -d ${agent_dir}",
       creates   => "${agent_dir}/conf",
       logoutput => 'on_failure',
       require   => Wget::Fetch['teamcity-buildagent']

--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -58,5 +58,15 @@ class teamcity::agent::service {
         'systemd' => File['/lib/systemd/system/build-agent.service'],
       }
     }
+    if $service_run_type == "systemd" {
+      exec { "systemd_reload":
+        command     => '/bin/systemctl daemon-reload',
+        refreshonly => true,
+      }
+    }else{
+      file { "/lib/systemd/system/build-agent.service":
+        ensure  => absent,
+      }
+    }
   }
 }

--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -52,7 +52,11 @@ class teamcity::agent::service {
       enable     => $service_enable,
       hasstatus  => true,
       hasrestart => true,
-      require    => File['/etc/init.d/build-agent']
+      provider   => $service_run_type,
+      require    => $service_run_type ? {
+        'init' => File['/etc/init.d/build-agent'],
+        'systemd' => File['/lib/systemd/system/build-agent.service'],
+      }
     }
   }
 }

--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -47,16 +47,17 @@ class teamcity::agent::service {
     }
   }
   else {
+    $service_run_type_file = $service_run_type ? {
+      'init' => File['/etc/init.d/build-agent'],
+      'systemd' => File['/lib/systemd/system/build-agent.service'],
+    }
     service { 'build-agent':
       ensure     => $service_ensure,
       enable     => $service_enable,
       hasstatus  => true,
       hasrestart => true,
       provider   => $service_run_type,
-      require    => $service_run_type ? {
-        'init' => File['/etc/init.d/build-agent'],
-        'systemd' => File['/lib/systemd/system/build-agent.service'],
-      }
+      require    => $service_run_type_file,
     }
     if $service_run_type == "systemd" {
       exec { "systemd_reload":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,12 @@ class teamcity::params {
 
   $service_ensure          = 'running'
   $service_enable          = true
-  $service_run_type        = 'service'
+  if $::kernel == 'windows' {
+    $service_run_type        = 'service'
+  }
+  else {
+    $service_run_type        = 'init'
+  }
   $teamcity_agent_mem_opts = '-Xms512m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
   $custom_properties       = {}
   $launcher_wrapper_conf   = {}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,10 +26,9 @@ class teamcity::params {
   }
   else {
     if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
-        $service_run_type = 'systemd'
-      } else {
-        $service_run_type = 'init'
-      }
+      $service_run_type = 'systemd'
+    } else {
+      $service_run_type = 'init'
     }
   }
   $teamcity_agent_mem_opts = '-Xms512m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,12 @@ class teamcity::params {
     $service_run_type        = 'service'
   }
   else {
-    $service_run_type        = 'init'
+    if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+        $service_run_type = 'systemd'
+      } else {
+        $service_run_type = 'init'
+      }
+    }
   }
   $teamcity_agent_mem_opts = '-Xms512m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
   $custom_properties       = {}

--- a/templates/build-agent-service.erb
+++ b/templates/build-agent-service.erb
@@ -1,0 +1,11 @@
+# File is managed by Puppet
+
+[Unit]
+Description=TeamCity build agent
+
+[Service]
+User=<%= @agent_user %>
+ExecStart=<%= @agent_dir %>/bin/agent.sh run
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/build-agent-service.erb
+++ b/templates/build-agent-service.erb
@@ -8,7 +8,7 @@ After=network.target
 Type=forking
 User=<%= @agent_user %>
 PIDFile=<%= @agent_dir %>/logs/buildAgent.pid
-ExecStart=<%= @agent_dir %>/bin/agent.sh run
+ExecStart=<%= @agent_dir %>/bin/agent.sh start
 ExecStop=<%= @agent_dir %>/bin/agent.sh stop
 
 [Install]

--- a/templates/build-agent-service.erb
+++ b/templates/build-agent-service.erb
@@ -1,11 +1,15 @@
 # File is managed by Puppet
 
 [Unit]
-Description=TeamCity build agent
+Description=TeamCity Build Agent
+After=network.target
 
 [Service]
+Type=forking
 User=<%= @agent_user %>
+PIDFile=<%= @agent_dir %>/logs/buildAgent.pid
 ExecStart=<%= @agent_dir %>/bin/agent.sh start
+ExecStop=<%= @agent_dir %>/bin/agent.sh stop
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/build-agent-service.erb
+++ b/templates/build-agent-service.erb
@@ -2,14 +2,10 @@
 
 [Unit]
 Description=TeamCity build agent
-After=network.target
 
 [Service]
-Type=forking
 User=<%= @agent_user %>
-PIDFile=<%= @agent_dir %>/logs/buildAgent.pid
 ExecStart=<%= @agent_dir %>/bin/agent.sh start
-ExecStop=<%= @agent_dir %>/bin/agent.sh stop
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/build-agent-service.erb
+++ b/templates/build-agent-service.erb
@@ -2,10 +2,14 @@
 
 [Unit]
 Description=TeamCity build agent
+After=network.target
 
 [Service]
+Type=forking
 User=<%= @agent_user %>
+PIDFile=<%= @agent_dir %>/logs/buildAgent.pid
 ExecStart=<%= @agent_dir %>/bin/agent.sh run
+ExecStop=<%= @agent_dir %>/bin/agent.sh stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added template to generate build-agent.service to allow latest versions of Ubuntu and Debian to run the service using systemctl.

Added missing $agent_user to config. Some templates were missing the agent user.

I'm just new to puppet so feel free to comment.