### PR TITLE
puppet 4 fixes and el6 init.d support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
 source 'https://rubygems.org'
 
-puppetversion = ENV['PUPPET_VERSION'] || '~> 3.8.0'
+puppetversion = ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
 gem 'puppet', puppetversion, :require => false
 
 gem 'metadata-json-lint'
-gem 'puppet', puppetversion
 gem 'rspec-puppet'
 gem 'rspec-puppet-utils'
 

--- a/manifests/agent/service/initd.pp
+++ b/manifests/agent/service/initd.pp
@@ -1,13 +1,24 @@
 # PRIVATE CLASS: do not call directly
 # Class for managing init.d service
-class teamcity::agent::service::initd {
+class teamcity::agent::service::initd (
+  $agent_dir = $teamcity::agent_dir,
+  $agent_user = $teamcity::agent_user,
+  ){
 
+  $service_template = $::operatingsystemmajrelease ? {
+    '6'     => 'build-agent-el6.erb',
+    default => 'build-agent.erb',
+  }
+
+  #Template uses these vars:
+  # agent_dir
+  # agent_user
   file { '/etc/init.d/build-agent':
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
-    content => template("${module_name}/build-agent.erb"),
+    content => template("${module_name}/${service_template}"),
     before  => Service['build-agent'],
     notify  => Service['build-agent'],
   }

--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -1,7 +1,13 @@
 # PRIVATE CLASS: do not call directly
 # Class for managing system.d service
-class teamcity::agent::service::systemd {
+class teamcity::agent::service::systemd (
+  $agent_dir  = $teamcity::agent_dir,
+  $agent_user = $teamcity::agent_user,
+  ){
 
+  #Template uses these vars:
+  # agent_dir
+  # agent_user
   file { '/lib/systemd/system/build-agent.service':
     ensure  => 'file',
     owner   => 'root',

--- a/spec/classes/teamcity_spec.rb
+++ b/spec/classes/teamcity_spec.rb
@@ -25,6 +25,9 @@ describe 'teamcity', :type => 'class' do
     context "on #{os}" do
       let(:facts) do
         facts
+        facts.merge({
+          :temp_dir => 'C:/temp',
+         })
       end
 
       context 'main class tests' do

--- a/templates/build-agent-el6.erb
+++ b/templates/build-agent-el6.erb
@@ -1,0 +1,82 @@
+#!/bin/sh -
+# File is managed by Puppet
+
+### BEGIN INIT INFO
+# Provides:          build-agent
+# Required-Start:    $local_fs $syslog
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Build agent management script
+### END INIT INFO
+#set -x
+
+NAME=build-agent
+DAEMON=/opt/build-agent/bin/agent.sh
+PIDFILE=/opt/build-agent/logs/buildAgent.pid
+USER=teamcity
+
+# If the daemon is not there, then exit.
+test -x $DAEMON || exit 5
+
+log_daemon_msg() {
+  echo "$@"
+  echo "$@" >> /var/log/$NAME.log
+}
+PID=`cat $PIDFILE 2>/dev/null `
+
+case $1 in
+start)
+  if [ -e $PIDFILE ]; then
+    `/bin/kill -0 $PID 2>/dev/null `
+    service_status=$?
+    if [[ $service_status = 0 ]]; then
+      log_daemon_msg "$NAME process is already running"
+      exit
+    fi
+  fi
+
+  log_daemon_msg "Starting the process" "$NAME"
+  su --login -c "$DAEMON start" $USER || log_daemon_msg "tried to start but failed"
+;;
+stop)
+  if [ -e $PIDFILE ]; then
+    `/bin/kill -0 $PID 2>/dev/null `
+    service_status=$?
+    if [[ $service_status = 0 ]]; then
+      su --login -c "$DAEMON stop" $USER || log_daemon_msg "tried to stop but failed"
+      rm -rf $PIDFILE
+    else
+      log_daemon_msg "$NAME process is not running"
+      echo "pid file found, but process doesn't exist.  removing pid file"
+      kill -9 $PID 2>/dev/null
+      pkill -f $NAME 2>/dev/null #teamcity child process can linger
+      rm -rf $PIDFILE
+    fi
+  else
+    echo "process already stopped"
+  fi
+;;
+restart)
+  $0 stop && sleep 10 && $0 start
+  ;;
+status)
+  if [ -e $PIDFILE ]; then
+    `/bin/kill -0 $PID 2>/dev/null `
+    service_status=$?
+    if [[ $service_status = 1 ]]; then
+      echo "pid file found, but process doesn't exist.  removing pid file"
+      kill -9 $PID 2>/dev/null
+      pkill -f teamcity-agent 2>/dev/null #teamcity child process can linger
+      rm -rf $PIDFILE
+    else
+      log_daemon_msg "$NAME is running"
+    fi
+  else
+    log_daemon_msg "$NAME Process is not running"
+  fi
+;;
+*)
+  echo "Usage: $0 {start|stop|restart|service_status}"
+  exit 2
+esac


### PR DESCRIPTION
el6 doesn't have the functions available to it in the lsb init-functions
el6 will now redirect to it's own init.d script
